### PR TITLE
Odd-shaped part hitpoint balance

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
@@ -2,7 +2,7 @@
 //Fixes for Mass/Density anomoalies in KSP
 ///////////////////////////////////////////
 
-@PART[turboJet]
+@PART[turboJet] //J-404 "Panther" Afterburning Turbofan
 {
 	%MODULE[HitpointTracker]
 	{
@@ -10,10 +10,8 @@
 		maxHitPoints = 2000
 		ExplodeMode = Never
 	}	
-
 }
-
-@PART[elevon*]
+@PART[elevon*] //Elevon 2, Elevon 3, Elevon 5
 {
 	%MODULE[HitpointTracker]
 	{
@@ -21,11 +19,17 @@
 		maxHitPoints = 500
 		ExplodeMode = Never
 	}	
-
 }
-
-
-@PART[B9.Aero.Wing.Procedural.TypeB]
+@PART[smallCtrlSrf] //Elevon 4
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 200
+		ExplodeMode = Never
+	}	
+}
+@PART[B9.Aero.Wing.Procedural.TypeB] //defunct or non-stock??
 {
 	%MODULE[HitpointTracker]
 	{
@@ -33,53 +37,43 @@
 		maxHitPoints = 500
 		ExplodeMode = Never
 	}	
-
 }
-
-@PART[winglet3]
+@PART[winglet3] //Delta-Deluxe Winglet
 {
 	%MODULE[HitpointTracker]
 	{
 		ArmorThickness = 10
-		maxHitPoints = 650
+		maxHitPoints = 400 //nerf
 		ExplodeMode = Never
 	}	
-
 }
-
-@PART[tailfin]
+@PART[tailfin] //Tail Fin
 {
 	%MODULE[HitpointTracker]
 	{
 		ArmorThickness = 10
-		maxHitPoints = 750
+		maxHitPoints = 450 //nerf
 		ExplodeMode = Never
 	}	
-
 }
-
-@PART[AdvancedCanard]
+@PART[AdvancedCanard] //Advanced Canard
 {
 	%MODULE[HitpointTracker]
 	{
 		ArmorThickness = 10
-		maxHitPoints = 750
+		maxHitPoints = 400 //nerf
 		ExplodeMode = Never
 	}	
-
 }
-
-@PART[CanardController]
+@PART[CanardController] //Standard Canard
 {
 	%MODULE[HitpointTracker]
 	{
 		ArmorThickness = 10
-		maxHitPoints = 750
+		maxHitPoints = 400 //nerf
 		ExplodeMode = Never
 	}	
-
 }
-
 @PART[nacelleBody]
 {
 	%MODULE[HitpointTracker]
@@ -88,16 +82,203 @@
 		maxHitPoints = 750
 		ExplodeMode = Never
 	}	
-
 }
-
 @PART[ramAirIntake]
 {
 	%MODULE[HitpointTracker]
 	{
 		ArmorThickness = 10
-		maxHitPoints = 300
+		maxHitPoints = 350
+		ExplodeMode = Never
+	}	
+}
+@PART[wingShuttleDelta] //Big-S Delta Wing
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 2800 //nerf, default 4700 (wow)
 		ExplodeMode = Never
 	}	
 
+}
+@PART[wingShuttleElevon2] //Big-S Elevon 2
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 1100 //buff, scale Big-S Elevon 1
+		ExplodeMode = Never
+	}	
+}
+@PART[wingShuttleRudder] //Big-S Spaceplane Tail Fin
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 2400 //buff, scale FAT-455 Aeroplane Tail Fin
+		ExplodeMode = Never
+	}	
+}
+@PART[wingShuttleStrake] //Big-S Wing Strake
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 700 //buff, scale Wing Connector Type C
+		ExplodeMode = Never
+	}	
+}
+@PART[deltaWing] //Delta Wing
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 1400 //buff, match Wing Connector type A
+		ExplodeMode = Never
+	}	
+}
+@PART[delta_small] //Small Delta Wing
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 400 //buff, scale Wing Connector Type C
+		ExplodeMode = Never
+	}	
+}
+@PART[structuralWing] //Structural Wing Type A
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 700 //buff, match Wing Connector type C
+		ExplodeMode = Never
+	}	
+}
+@PART[structuralWing2] //Structural Wing Type B
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 700 //buff, match Wing Connector type C
+		ExplodeMode = Never
+	}	
+}
+@PART[structuralWing3] //Structural Wing Type C
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 400 //buff, match Wing Connector type D
+		ExplodeMode = Never
+	}	
+}
+@PART[structuralWing4] //Structural Wing Type D
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 200 //buff, scale Wing Connector type D
+		ExplodeMode = Never
+	}	
+}
+@PART[sweptWing1] //Swept Wing Type A
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 700 //buff, match Wing Connector type C
+		ExplodeMode = Never
+	}	
+}
+@PART[sweptWing2] //Swept Wing Type B
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 1400 //buff, match Wing Connector type A
+		ExplodeMode = Never
+	}	
+}
+@PART[wingStrake] //Wing Strake
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 350 //buff, match Wing Connector type D
+		ExplodeMode = Never
+	}	
+}
+@PART[airlinerMainWing] //FAT-455 Aeroplane Main Wing
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 5000 //buff from 400, scale from lifting surface of other wings, this should now be a viable part
+		ExplodeMode = Never
+	}	
+}
+@PART[R8winglet] //AV-R8 Winglet
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 200 //buff
+		ExplodeMode = Never
+	}	
+}
+@PART[winglet] //AV-T1 Winglet
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 200 //buff
+		ExplodeMode = Never
+	}	
+}
+@PART[structuralIBeam1] //M-Beam 650 I-Beam
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 400 //buff, scale to 
+		ExplodeMode = Never
+	}	
+}
+@PART[lGripPad] //GP-156 Grip Pad
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 600 //buff, scale GP-036 Grip Pad
+		ExplodeMode = Never
+	}	
+}
+@PART[largeAdapter] //Rockomax Brand Adapter
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 1000 //buff, scale 2.5m tanks
+		ExplodeMode = Never
+	}	
+}
+@PART[radPanelEdge] //Radiator Panel (edge)
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 300 //buff, scale Radiator Panel (large)
+		ExplodeMode = Never
+	}	
+}
+@PART[InflatableHeatShield] //Heat Shield (10m)
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 1600 //nerfed from 5600, I'm glad people didn't know about this, this part was even more OP than the original shuttle wing!
+		ExplodeMode = Never
+	}	
 }

--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
@@ -90,3 +90,14 @@
 	}	
 
 }
+
+@PART[ramAirIntake]
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 300
+		ExplodeMode = Never
+	}	
+
+}


### PR DESCRIPTION
Patch to properly scale triangular wings to have half the hitpoints of equivalent square/rectangular wings, plus a couple additional nerfs/buffs to extreme outliers.

BDA calculates hitpoints of a part based off of its mass vs how large a 3d cube it fills. Because of this it does a poor job of scaling parts that are not rectangular. Ex. triangular wings have half the mass of square wings of the same dimensions, so the equation thinks the part is half as dense and scales its hitpoints accordingly: https://i.imgur.com/XyaRMfg.png

 This patch balances a majority of non-rectangular parts with outlying hitpoints, and balances triangular wings to have half the hitpoints of equivalent square/rectangular wings. Each part has the in-game title and buff/nerf and reasoning next to it.