### PR TITLE
Remove Big-S Delta Wing nerf

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
@@ -92,16 +92,6 @@
 		ExplodeMode = Never
 	}	
 }
-@PART[wingShuttleDelta] //Big-S Delta Wing
-{
-	%MODULE[HitpointTracker]
-	{
-		ArmorThickness = 10
-		maxHitPoints = 2800 //nerf, default 4700 (wow)
-		ExplodeMode = Never
-	}	
-
-}
 @PART[wingShuttleElevon2] //Big-S Elevon 2
 {
 	%MODULE[HitpointTracker]
@@ -278,7 +268,7 @@
 	%MODULE[HitpointTracker]
 	{
 		ArmorThickness = 10
-		maxHitPoints = 1600 //nerfed from 5600, I'm glad people didn't know about this, this part was even more OP than the original shuttle wing!
+		maxHitPoints = 1600 //nerf, original was 5600 due to scaling with the inflated model size
 		ExplodeMode = Never
 	}	
 }


### PR DESCRIPTION
Looking back, this was a needless nerf and would make the big-S wing worse than some other options at its size